### PR TITLE
Urllib3 Compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ NAME = "hubspot-api-client"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3 >= 2.0", "six >= 1.10", "certifi", "python-dateutil"]
 DEV_REQUIRES = ["pytest", "black"]
 
 DIR_PATH = dirname(abspath(__file__))


### PR DESCRIPTION
Urllib3 compat version >= 2.0 
DeprecationWarnings removed on 2.1.0 

https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#what-are-the-important-changes